### PR TITLE
Using java.io.File.separator instead of a slash character in Res.scala

### DIFF
--- a/app/se/digiplant/res/api/Res.scala
+++ b/app/se/digiplant/res/api/Res.scala
@@ -128,7 +128,7 @@ object Res {
    */
   def delete(fileuid: String, source: String = "default", meta: Seq[String] = Nil): Boolean = get(fileuid, source, meta).exists(_.delete())
 
-  private def hashAsDirectories(hash: String): String = hash.substring(0, 4) + '/' + hash.substring(4, 8)
+  private def hashAsDirectories(hash: String): String = hash.substring(0, 4) + File.separator + hash.substring(4, 8)
 
   /**
    * Retrieves a file with the specified filepath and if specified all meta attributes


### PR DESCRIPTION
It is recommended to use java.io.File.separator instead of a single slash character ('/'), because slash is platform dependent.